### PR TITLE
fix: render split tests through API

### DIFF
--- a/public/funnelpage-template.php
+++ b/public/funnelpage-template.php
@@ -22,21 +22,34 @@ if ($splitTestsEnabled) {
 		}
 	}
 
-	$response = wp_remote_get('https://page.funnelcockpit.com/' . $funnelPageId, [
+	$response = wp_remote_get('https://api.funnelcockpit.com/funnel-page/' . $funnelPageId, [
 		'timeout' => 10,
 		'cookies' => $cookies
 	]);
 	if ($response['response']['code'] == 200 && isset($response['body'])) {
-		foreach ($response['cookies'] as $cookie) {
-			if (strpos($cookie->name, 'funnelPage') !== false) {
-				setcookie($cookie->name, $cookie->value, time() + (60 * 60 * 24 * 30));
-			}
-		}
+		$funnelPage = json_decode($response['body']);
+		if (!empty($funnelPage) && isset($funnelPage->head) && isset($funnelPage->body)) {
 
-		// Output trusted HTML content from FunnelCockpit service
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $response['body'];
-		die();
+			foreach ($response['cookies'] as $cookie) {
+				if (strpos($cookie->name, 'funnelPage') !== false) {
+					setcookie($cookie->name, $cookie->value, time() + (60 * 60 * 24 * 30));
+				}
+			}
+
+			// Output trusted HTML content from FunnelCockpit service
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<!DOCTYPE html><html>';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $funnelPage->head;
+			if (get_option('funnelcockpit_print_head') == 'on') {
+				wp_head();
+			}
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo str_replace('</body>', '', $funnelPage->body);
+			wp_footer();
+			echo '</body></html>';
+			die();
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change split-test rendering in the WordPress template to call `https://api.funnelcockpit.com/funnel-page/{id}` instead of `https://page.funnelcockpit.com/{id}`.
- Decode the API JSON response and render the returned head/body directly for split-test pages.
- Preserve the split-test cookie forwarding behavior.

## Root Cause
The plugin used the public page domain for split-test rendering, but server-side requests to `page.funnelcockpit.com` can be blocked by Cloudflare challenges. The plugin then silently falls back to cached API HTML, which previously rendered only the main page.

## Validation
- `git diff --check`

Note: PHP lint could not be run locally because `php` is not installed in this environment, and this checkout does not have Composer `vendor/` installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/funnelcockpit/codesmith/funnelcockpit-wordpress/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->