### PR TITLE
chore: release WordPress plugin 1.5.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://funnelcockpit.com/
 Tags: funnelcockpit, funnel, cockpit
 Requires at least: 3.0.1
 Tested up to: 7.0
-Stable tag: 1.4.9
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,10 @@ More information: https://funnelcockpit.com/
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 1.5.0 =
+* Fixed split-test page rendering through the FunnelCockpit API
+* Improved split-test compatibility when public FunnelCockpit page fetches are blocked
 
 = 1.4.9 =
 * Confirmed compatibility with WordPress 7.0

--- a/funnelcockpit.php
+++ b/funnelcockpit.php
@@ -16,7 +16,7 @@
  * Plugin Name:       FunnelCockpit
  * Plugin URI:        https://funnelcockpit.com
  * Description:       Publish FunnelCockpit funnels and landing pages on your WordPress site.
- * Version:           1.4.9
+ * Version:           1.5.0
  * Author:            FunnelCockpit
  * Author URI:        https://funnelcockpit.com
  * License:           GPL-2.0+

--- a/includes/class-funnelcockpit.php
+++ b/includes/class-funnelcockpit.php
@@ -73,7 +73,7 @@ class FunnelCockpit {
 	public function __construct() {
 
 		$this->funnelcockpit = 'funnelcockpit';
-		$this->version = '1.4.9';
+		$this->version = '1.5.0';
 
 		$this->load_dependencies();
 		$this->set_locale();


### PR DESCRIPTION
## Summary
- bump the WordPress plugin version from 1.4.9 to 1.5.0
- update the README stable tag
- add a 1.5.0 changelog entry for the split-test rendering fix

## Notes
This release PR is based on the merged split-test rendering fix from #9.

## Validation
- `git diff --check`
- verified all plugin version markers point at `1.5.0`

PHP CLI is not installed locally, so PHP syntax checks were not run here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/funnelcockpit/codesmith/funnelcockpit-wordpress/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->