### PR TITLE
[codex] Validate release tags before deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Validate release tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+
+          if [[ ! "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tags must be unprefixed semver, for example 1.5.2. Got: $tag"
+            exit 1
+          fi
+
+          plugin_version="$(sed -nE 's/.*Version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' funnelcockpit.php | head -n 1)"
+          stable_tag="$(sed -nE 's/^Stable tag:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' README.txt | head -n 1)"
+
+          if [[ "$plugin_version" != "$tag" ]]; then
+            echo "::error::funnelcockpit.php Version ($plugin_version) must match release tag ($tag)."
+            exit 1
+          fi
+
+          if [[ "$stable_tag" != "$tag" ]]; then
+            echo "::error::README.txt Stable tag ($stable_tag) must match release tag ($tag)."
+            exit 1
+          fi
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Summary
- Add a release workflow guard that only allows unprefixed semver tags like `1.5.2`.
- Fail the release before deployment when `funnelcockpit.php` `Version` does not match the Git tag.
- Fail the release before deployment when `README.txt` `Stable tag` does not match the Git tag.

## Why
The repository has historical mixed `vX.Y.Z` and `X.Y.Z` tags, and the deploy script creates WordPress.org SVN tags directly from `GITHUB_REF_NAME`. This guard prevents future prefixed or mismatched tags from creating more incorrect release artifacts.

## Validation
- Parsed `.github/workflows/release.yml` as YAML.
- Ran `git diff --check`.
- Smoke-tested the validation logic locally: `1.5.1` passes and `v1.5.1` fails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/funnelcockpit/codesmith/funnelcockpit-wordpress/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782654671&installation_id=128355403&pr_number=12&repository=funnelcockpit%2Ffunnelcockpit-wordpress&return_to=https%3A%2F%2Fgithub.com%2Ffunnelcockpit%2Ffunnelcockpit-wordpress%2Fpull%2F12&signature=ddbdedc2efeffa4646c92846da32adc651d0dec386e6d7923e71a020e0a22513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->